### PR TITLE
Fixed PCM endianness bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,8 +59,13 @@ jobs:
           path: nativelibs
           retention-days: 1
 
+      - name: Get project version
+        id: get_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --file pom.xml)" >> $GITHUB_OUTPUT
+
       - id: publish-native-lib-to-central
         name: Publish to Central Repository
+        if: ${{ !endsWith(steps.get_version.outputs.version, 'SNAPSHOT') }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -120,8 +125,13 @@ jobs:
           path: nativelibs
           retention-days: 1
 
+      - name: Get project version
+        id: get_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --file pom.xml)" >> $GITHUB_OUTPUT
+
       - id: publish-native-lib-to-central
         name: Publish to Central Repository
+        if: ${{ !endsWith(steps.get_version.outputs.version, 'SNAPSHOT') }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -172,8 +182,13 @@ jobs:
           path: nativelibs
           retention-days: 1
 
+      - name: Get project version
+        id: get_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --file pom.xml)" >> $GITHUB_OUTPUT
+
       - id: publish-native-lib-to-central
         name: Publish to Central Repository
+        if: ${{ !endsWith(steps.get_version.outputs.version, 'SNAPSHOT') }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -224,8 +239,13 @@ jobs:
           path: nativelibs
           retention-days: 1
 
+      - name: Get project version
+        id: get_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --file pom.xml)" >> $GITHUB_OUTPUT
+
       - id: publish-native-lib-to-central
         name: Publish to Central Repository
+        if: ${{ !endsWith(steps.get_version.outputs.version, 'SNAPSHOT') }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -283,8 +303,13 @@ jobs:
           path: nativelibs
           retention-days: 1
 
+      - name: Get project version
+        id: get_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --file pom.xml)" >> $GITHUB_OUTPUT
+
       - id: publish-to-central
         name: Publish to Central Repository
+        if: ${{ !endsWith(steps.get_version.outputs.version, 'SNAPSHOT') }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -374,8 +399,13 @@ jobs:
           name: nativelibs-x64-win
           path: ffsampledsp-complete/target/classes/
 
+      - name: Get project version
+        id: get_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --file pom.xml)" >> $GITHUB_OUTPUT
+
       - id: publish-to-central
         name: Publish to Central Repository
+        if: ${{ !endsWith(steps.get_version.outputs.version, 'SNAPSHOT') }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,6 @@
 - 0.9.56
-  - Fixed deployment to tagtraum
+  - Fixed deployment to tagtraum.
+  - Fixed PCM endianness bug.
 
 
 - 0.9.55

--- a/ffsampledsp-complete/src/test/java/com/tagtraum/ffsampledsp/TestFFCodecInputStream.java
+++ b/ffsampledsp-complete/src/test/java/com/tagtraum/ffsampledsp/TestFFCodecInputStream.java
@@ -1300,6 +1300,150 @@ public class TestFFCodecInputStream {
     assertTrue("Expected upsample to produce more bytes than source", bytesRead > 534528);
   }
 
+  /**
+   * The raw FFAudioInputStream from an AIFF file must deliver big-endian bytes (matching its
+   * reported isBigEndian()=true). Before the fix, the stream delivered native-LE bytes despite
+   * claiming BE, making it byte-for-byte identical to a LE-converted stream.
+   */
+  @Test
+  public void testRawAiffStreamBytesDifferFromLittleEndianConversion()
+      throws IOException, UnsupportedAudioFileException {
+    final String filename = "test.aiff";
+    final File fileRaw = File.createTempFile("testRawAiffRaw", filename);
+    final File fileLE = File.createTempFile("testRawAiffLE", filename);
+    extractFile(filename, fileRaw);
+    extractFile(filename, fileLE);
+    try {
+      final byte[] rawBytes;
+      try (final AudioInputStream src = new FFAudioFileReader().getAudioInputStream(fileRaw)) {
+        assertTrue("AIFF source must be big-endian", src.getFormat().isBigEndian());
+        final byte[] buf = new byte[4096];
+        final java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        int n;
+        while ((n = src.read(buf)) != -1) {
+          baos.write(buf, 0, n);
+        }
+        rawBytes = baos.toByteArray();
+      }
+      final byte[] leBytes;
+      try (final AudioInputStream src = new FFAudioFileReader().getAudioInputStream(fileLE)) {
+        final AudioFormat fmt = src.getFormat();
+        final AudioFormat leTarget =
+            new AudioFormat(
+                AudioFormat.Encoding.PCM_SIGNED,
+                fmt.getSampleRate(),
+                fmt.getSampleSizeInBits(),
+                fmt.getChannels(),
+                fmt.getFrameSize(),
+                fmt.getSampleRate(),
+                false);
+        leBytes = readAllBytes(new FFCodecInputStream(leTarget, (FFAudioInputStream) src));
+      }
+      assertFalse(
+          "Raw AIFF stream (isBigEndian=true) must not be byte-for-byte identical to"
+              + " LE-converted stream — raw bytes must be big-endian",
+          java.util.Arrays.equals(rawBytes, leBytes));
+    } finally {
+      fileRaw.delete();
+      fileLE.delete();
+    }
+  }
+
+  @Test
+  public void testAiffLittleEndianAndBigEndianDiffer()
+      throws IOException, UnsupportedAudioFileException {
+    final String filename = "test.aiff";
+    final File fileLE = File.createTempFile("testAiffLEandBEDifferLE", filename);
+    final File fileBE = File.createTempFile("testAiffLEandBEDifferBE", filename);
+    extractFile(filename, fileLE);
+    extractFile(filename, fileBE);
+    try {
+      final byte[] leBytes;
+      try (final AudioInputStream src = new FFAudioFileReader().getAudioInputStream(fileLE)) {
+        assertTrue("AIFF source must be big-endian", src.getFormat().isBigEndian());
+        final AudioFormat fmt = src.getFormat();
+        final AudioFormat leTarget =
+            new AudioFormat(
+                AudioFormat.Encoding.PCM_SIGNED,
+                fmt.getSampleRate(),
+                fmt.getSampleSizeInBits(),
+                fmt.getChannels(),
+                fmt.getFrameSize(),
+                fmt.getSampleRate(),
+                false);
+        leBytes = readAllBytes(new FFCodecInputStream(leTarget, (FFAudioInputStream) src));
+      }
+      final byte[] beBytes;
+      try (final AudioInputStream src = new FFAudioFileReader().getAudioInputStream(fileBE)) {
+        final AudioFormat fmt = src.getFormat();
+        final AudioFormat beTarget =
+            new AudioFormat(
+                AudioFormat.Encoding.PCM_SIGNED,
+                fmt.getSampleRate(),
+                fmt.getSampleSizeInBits(),
+                fmt.getChannels(),
+                fmt.getFrameSize(),
+                fmt.getSampleRate(),
+                true);
+        beBytes = readAllBytes(new FFCodecInputStream(beTarget, (FFAudioInputStream) src));
+      }
+      assertFalse(
+          "LE and BE conversions of AIFF must produce different byte sequences",
+          java.util.Arrays.equals(leBytes, beBytes));
+    } finally {
+      fileLE.delete();
+      fileBE.delete();
+    }
+  }
+
+  @Test
+  public void testAiffLittleEndianIsByteSwapOfBigEndian()
+      throws IOException, UnsupportedAudioFileException {
+    final String filename = "test.aiff";
+    final File fileLE = File.createTempFile("testAiffByteSwapLE", filename);
+    final File fileBE = File.createTempFile("testAiffByteSwapBE", filename);
+    extractFile(filename, fileLE);
+    extractFile(filename, fileBE);
+    try {
+      final byte[] leBytes;
+      try (final AudioInputStream src = new FFAudioFileReader().getAudioInputStream(fileLE)) {
+        final AudioFormat fmt = src.getFormat();
+        final AudioFormat leTarget =
+            new AudioFormat(
+                AudioFormat.Encoding.PCM_SIGNED,
+                fmt.getSampleRate(),
+                fmt.getSampleSizeInBits(),
+                fmt.getChannels(),
+                fmt.getFrameSize(),
+                fmt.getSampleRate(),
+                false);
+        leBytes = readAllBytes(new FFCodecInputStream(leTarget, (FFAudioInputStream) src));
+      }
+      final byte[] beBytes;
+      try (final AudioInputStream src = new FFAudioFileReader().getAudioInputStream(fileBE)) {
+        final AudioFormat fmt = src.getFormat();
+        final AudioFormat beTarget =
+            new AudioFormat(
+                AudioFormat.Encoding.PCM_SIGNED,
+                fmt.getSampleRate(),
+                fmt.getSampleSizeInBits(),
+                fmt.getChannels(),
+                fmt.getFrameSize(),
+                fmt.getSampleRate(),
+                true);
+        beBytes = readAllBytes(new FFCodecInputStream(beTarget, (FFAudioInputStream) src));
+      }
+      assertEquals("LE and BE outputs must have the same length", leBytes.length, beBytes.length);
+      for (int i = 0; i + 1 < leBytes.length; i += 2) {
+        assertEquals("Byte swap mismatch at sample offset " + (i / 2), leBytes[i], beBytes[i + 1]);
+        assertEquals("Byte swap mismatch at sample offset " + (i / 2), leBytes[i + 1], beBytes[i]);
+      }
+    } finally {
+      fileLE.delete();
+      fileBE.delete();
+    }
+  }
+
   private void extractFile(final String filename, final File file) throws IOException {
     try (final InputStream in = getClass().getResourceAsStream(filename);
         final OutputStream out = new FileOutputStream(file)) {
@@ -1308,6 +1452,20 @@ public class TestFFCodecInputStream {
       while ((justRead = in.read(buf)) != -1) {
         out.write(buf, 0, justRead);
       }
+    }
+  }
+
+  private byte[] readAllBytes(final FFCodecInputStream stream) throws IOException {
+    try {
+      final java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+      final byte[] buf = new byte[4096];
+      int n;
+      while ((n = stream.read(buf)) != -1) {
+        baos.write(buf, 0, n);
+      }
+      return baos.toByteArray();
+    } finally {
+      stream.close();
     }
   }
 }

--- a/ffsampledsp-x86_64-macos/src/main/c/FFUtils.c
+++ b/ffsampledsp-x86_64-macos/src/main/c/FFUtils.c
@@ -636,22 +636,29 @@ int ff_init_audioio(JNIEnv *env, FFAudioIO *aio) {
     // exception is already thrown
     goto bail;
   }
-  // if for some reason the codec delivers 24bit, we need to encode its output
-  // to little endian
-  if (aio->stream->codecpar->bits_per_coded_sample == 24) {
-    codec = ff_find_encoder(aio->stream->codecpar->format,
-                            aio->stream->codecpar->bits_per_coded_sample,
-                            ff_big_endian(aio->stream->codecpar->codec_id), 1);
-    if (!codec) {
-      res = AVERROR(EINVAL);
-      throwIOExceptionIfError(env, res,
-                              "Could not find suitable encoder codec.");
-      goto bail;
-    }
-    res = ff_init_encoder(env, aio, codec);
-    if (res < 0) {
-      throwIOExceptionIfError(env, res, "Could not initialize encoder codec.");
-      goto bail;
+  // Install a PCM encoder when the decoded output needs byte-order adjustment:
+  // - 24-bit: decoder outputs S32-padded frames; encoder repacks to 24-bit
+  // - multi-byte big-endian sources: FFmpeg's PCM decoder produces native-LE
+  //   frames regardless of the on-disk byte order, so without an encoder the
+  //   Java buffer would receive LE bytes while the AudioFormat reports BE.
+  {
+    int src_bits = aio->stream->codecpar->bits_per_coded_sample;
+    int src_big_endian = ff_big_endian(aio->stream->codecpar->codec_id);
+    if (src_bits == 24 || (src_big_endian && src_bits > 8)) {
+      codec = ff_find_encoder(aio->stream->codecpar->format, src_bits,
+                              src_big_endian, 1);
+      if (!codec) {
+        res = AVERROR(EINVAL);
+        throwIOExceptionIfError(env, res,
+                                "Could not find suitable encoder codec.");
+        goto bail;
+      }
+      res = ff_init_encoder(env, aio, codec);
+      if (res < 0) {
+        throwIOExceptionIfError(env, res,
+                                "Could not initialize encoder codec.");
+        goto bail;
+      }
     }
   }
 


### PR DESCRIPTION
Install a PCM encoder when the decoded output needs byte-order adjustment:
- 24-bit: decoder outputs S32-padded frames; encoder repacks to 24-bit
- multi-byte big-endian sources: FFmpeg's PCM decoder produces native-LE frames regardless of the on-disk byte order, so without an encoder the Java buffer would receive LE bytes while the AudioFormat reports BE.

This bug showed up, when decoding AIFF files.
